### PR TITLE
Fix memory leak in expander function

### DIFF
--- a/includes/parsing.h
+++ b/includes/parsing.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parsing.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: achabrer <achabrer@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: jgomes-v <jgomes-v@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/08 11:48:41 by achabrer          #+#    #+#             */
-/*   Updated: 2024/01/31 11:27:25 by achabrer         ###   ########.fr       */
+/*   Updated: 2024/01/31 12:22:44 by jgomes-v         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -256,5 +256,9 @@ char	*expand_variable(char *content);
  * It skips tokens of type REDIR2_OUT.
  */
 void	expander(void);
+char	*get_key_expansion(char **temp);
+char	*append_value_to_content(char *new_content, char *value);
+char	*append_char_to_content(char *new_content, char c);
+char	*append_value_to_content_error(char *new_content, char *value);
 
 #endif

--- a/srcs/parsing/expander.c
+++ b/srcs/parsing/expander.c
@@ -3,49 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   expander.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: achabrer <achabrer@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: jgomes-v <jgomes-v@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/20 17:49:43 by jgomes-v          #+#    #+#             */
-/*   Updated: 2024/01/30 11:11:38 by achabrer         ###   ########.fr       */
+/*   Updated: 2024/01/31 12:23:36 by jgomes-v         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-char	*get_key_expansion(char **temp)
-{
-	char	*start;
-	char	*key;
-
-	start = ++(*temp);
-	while (**temp && (ft_isalnum(**temp) || **temp == '_'))
-		(*temp)++;
-	key = ft_strdup(start);
-	key[*temp - start] = '\0';
-	(*temp)--;
-	return (key);
-}
-
-char	*append_value_to_content(char *new_content, char *value)
-{
-	size_t	old_len;
-
-	old_len = ft_strlen(new_content);
-	new_content = ft_realloc_str(new_content, old_len + ft_strlen(value) + 1);
-	ft_strlcat(new_content, value, old_len + ft_strlen(value) + 1);
-	return (new_content);
-}
-
-char	*append_char_to_content(char *new_content, char c)
-{
-	size_t	old_len;
-
-	old_len = ft_strlen(new_content);
-	new_content = ft_realloc_str(new_content, old_len + 2);
-	new_content[old_len] = c;
-	new_content[old_len + 1] = '\0';
-	return (new_content);
-}
 char	*expand_variable(char *cnt)
 {
 	char	*new;
@@ -88,7 +54,7 @@ char	*expand_variable(char *cnt)
 			cnt++;
 		else if (*cnt == '$' && *(cnt + 1) == '?' && !in_single_quotes)
 		{
-			new = append_value_to_content(new, ft_itoa(sh()->exit_status));
+			new = append_value_to_content_error(new, ft_itoa(sh()->exit_status));
 			cnt++;
 		}
 		else

--- a/srcs/parsing/expander_utils.c
+++ b/srcs/parsing/expander_utils.c
@@ -1,0 +1,49 @@
+
+#include "../../includes/minishell.h"
+
+char	*get_key_expansion(char **temp)
+{
+	char	*start;
+	char	*key;
+
+	start = ++(*temp);
+	while (**temp && (ft_isalnum(**temp) || **temp == '_'))
+		(*temp)++;
+	key = ft_strdup(start);
+	key[*temp - start] = '\0';
+	(*temp)--;
+	return (key);
+}
+
+char	*append_value_to_content(char *new_content, char *value)
+{
+	size_t	old_len;
+
+	old_len = ft_strlen(new_content);
+	new_content = ft_realloc_str(new_content, old_len + ft_strlen(value) + 1);
+	ft_strlcat(new_content, value, old_len + ft_strlen(value) + 1);
+	//free(value);
+	return (new_content);
+}
+
+char	*append_value_to_content_error(char *new_content, char *value)
+{
+	size_t	old_len;
+
+	old_len = ft_strlen(new_content);
+	new_content = ft_realloc_str(new_content, old_len + ft_strlen(value) + 1);
+	ft_strlcat(new_content, value, old_len + ft_strlen(value) + 1);
+	free(value);
+	return (new_content);
+}
+
+char	*append_char_to_content(char *new_content, char c)
+{
+	size_t	old_len;
+
+	old_len = ft_strlen(new_content);
+	new_content = ft_realloc_str(new_content, old_len + 2);
+	new_content[old_len] = c;
+	new_content[old_len + 1] = '\0';
+	return (new_content);
+}


### PR DESCRIPTION
This pull request fixes a memory leak issue in the expander function. The function was not properly freeing the memory allocated for the value when appending it to the new_content string. This caused a memory leak in certain scenarios. The fix includes updating the append_value_to_content function to properly free the value after appending it to the new_content string. This ensures that the memory is properly released and prevents memory leaks.